### PR TITLE
Handling 401 and 403 errors across website

### DIFF
--- a/client/src/components/catalogue/AddCaseStudy.tsx
+++ b/client/src/components/catalogue/AddCaseStudy.tsx
@@ -202,7 +202,6 @@ export default function AddCaseStudy() {
 
   return (
     <div>
-      <NavBar></NavBar>
       <div style={{margin: '0px 200px'}}>
         <DialogTitle>Ajouter une étude de cas</DialogTitle>
         <DialogContent>

--- a/client/src/components/catalogue/Catalogue.tsx
+++ b/client/src/components/catalogue/Catalogue.tsx
@@ -369,7 +369,6 @@ export default function Catalogue() {
 
   return (
     <div>
-      <NavBar></NavBar>
       <div id="content">
         <div id="rectangle">
           <div id="catalogue-des-cas">Catalogue des cas</div>

--- a/client/src/components/common/NavBar.tsx
+++ b/client/src/components/common/NavBar.tsx
@@ -1,7 +1,7 @@
 import { Button, ButtonGroup } from "@mui/material";
-import React, { useCallback } from "react";
+import React, { forwardRef, useCallback, useImperativeHandle, useRef, useState } from "react";
 import "./NavBar.scss";
-import Login from "../connection/Login";
+import Login, { LoginRef } from "../connection/Login";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import { useNavigate } from "react-router-dom";
@@ -10,7 +10,22 @@ import { UnlockAccess } from "../connection/UnlockAccess";
 
 interface Props {}
 
-const NavBar: React.FC<Props> = ({}) => {
+export interface NavBarRef {
+  SetIsLoggedIn(value: boolean): void;
+}
+
+const NavBar = forwardRef<NavBarRef, Props>(
+  (_props, ref) => {
+  useImperativeHandle(ref, () => ({
+    SetIsLoggedIn(value: boolean) {
+      if(loginRef.current) {
+        loginRef.current.SetIsLoggedIn(value);
+      }
+    },
+  }));
+  
+  const loginRef = useRef<LoginRef | null>(null);
+
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
   const handleOpen = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -84,10 +99,10 @@ const NavBar: React.FC<Props> = ({}) => {
         </span>
       </div>
       <div id="loginStatus">
-        <Login />
+        <Login ref={loginRef}/>
       </div>
     </div>
   );
-};
+});
 
 export default NavBar;

--- a/client/src/components/connection/LoginPopup.tsx
+++ b/client/src/components/connection/LoginPopup.tsx
@@ -67,6 +67,8 @@ const LoginPopup = forwardRef<LoginPopupRef, Props>(
             props.onLoggedIn(); // Refresh only Login/Logout button to not lose changes
           } 
           }
+      }).catch((err) => {
+        console.log(err);
       });
   };
       

--- a/client/src/components/guidePage/GuidePage.tsx
+++ b/client/src/components/guidePage/GuidePage.tsx
@@ -1,13 +1,14 @@
-import React from "react";
+import React, { useContext } from "react";
 import PdfAccordion from "./PdfAccordion";
 import "./GuidePage.scss";
 import NavBar from "../common/NavBar";
 import { Button, Typography } from "@mui/material";
 import Cookies from "js-cookie";
 import LoginPopup, { LoginPopupRef } from "./../connection/LoginPopup";
+import { AppContext } from "../App";
 
 function GuidePage() {
-  const loginPopupRef = React.useRef<LoginPopupRef | null>(null);
+  const appContext = useContext(AppContext);
 
   const numberOfUnrestrictedPdfFiles = 1;
   const numberOfRestrictedPdfFiles = 9;
@@ -35,14 +36,13 @@ function GuidePage() {
   }
 
   const openPopup = () => {
-    if (loginPopupRef.current) {
-      loginPopupRef.current.setPopupOpen();
+    if(appContext) {
+      appContext.openLogInPopup();
     }
   };
 
   return (
     <>
-      <NavBar></NavBar>
       <div className="guide-page">
         <h1>Ressources pédagogiques</h1>
         <h2>Comment rédiger et animer une étude de cas ?</h2>
@@ -73,7 +73,6 @@ function GuidePage() {
             />
           ))}
         </div>
-        <LoginPopup ref={loginPopupRef}/>
       </div>
     </>
   );

--- a/client/src/components/guidePage/GuidePage.tsx
+++ b/client/src/components/guidePage/GuidePage.tsx
@@ -1,10 +1,8 @@
 import React, { useContext } from "react";
 import PdfAccordion from "./PdfAccordion";
 import "./GuidePage.scss";
-import NavBar from "../common/NavBar";
 import { Button, Typography } from "@mui/material";
 import Cookies from "js-cookie";
-import LoginPopup, { LoginPopupRef } from "./../connection/LoginPopup";
 import { AppContext } from "../App";
 
 function GuidePage() {

--- a/client/src/components/pendingCaseStudies/PendingCaseStudies.tsx
+++ b/client/src/components/pendingCaseStudies/PendingCaseStudies.tsx
@@ -30,39 +30,43 @@ export default function PendingCaseStudies() {
     axios
       .get(`${process.env.REACT_APP_BASE_API_URL}/api/casestudies/user/${localStorage.getItem("email")}`, {withCredentials: true})
       .then((res) => {
-        const paidCases: Case[] = [];
-        const freeCases: Case[] = [];
-        for (const caseStudy of res.data) {
-          const newData = createCaseFromData(
-            caseStudy._id,
-            caseStudy.title,
-            caseStudy.desc,
-            caseStudy.authors,
-            caseStudy.submitter,
-            caseStudy.date,
-            caseStudy.page,
-            caseStudy.status,
-            caseStudy.isPaidCase,
-            caseStudy.isRejected,
-            caseStudy.classId,
-            caseStudy.discipline,
-            caseStudy.subjects,
-            caseStudy.files,
-            caseStudy.ratings,
-            caseStudy.votes
-          );
-          caseStudy.isPaidCase ? paidCases.push(newData) : freeCases.push(newData);
-        }
-        setPaidCaseStudiesStep1(filterByStep(paidCases, CaseStep.WaitingPreApproval));
-        setPaidCaseStudiesStep2(filterByStep(paidCases, CaseStep.WaitingComity));
-        setPaidCaseStudiesStep3(filterByStep(paidCases, CaseStep.WaitingCatalogue));
-        setPaidCaseStudiesStep4(filterByStep(paidCases, CaseStep.Posted));
+        if(res.status === 200) {
+          const paidCases: Case[] = [];
+          const freeCases: Case[] = [];
+          for (const caseStudy of res.data) {
+            const newData = createCaseFromData(
+              caseStudy._id,
+              caseStudy.title,
+              caseStudy.desc,
+              caseStudy.authors,
+              caseStudy.submitter,
+              caseStudy.date,
+              caseStudy.page,
+              caseStudy.status,
+              caseStudy.isPaidCase,
+              caseStudy.isRejected,
+              caseStudy.classId,
+              caseStudy.discipline,
+              caseStudy.subjects,
+              caseStudy.files,
+              caseStudy.ratings,
+              caseStudy.votes
+            );
+            caseStudy.isPaidCase ? paidCases.push(newData) : freeCases.push(newData);
+          }
+          setPaidCaseStudiesStep1(filterByStep(paidCases, CaseStep.WaitingPreApproval));
+          setPaidCaseStudiesStep2(filterByStep(paidCases, CaseStep.WaitingComity));
+          setPaidCaseStudiesStep3(filterByStep(paidCases, CaseStep.WaitingCatalogue));
+          setPaidCaseStudiesStep4(filterByStep(paidCases, CaseStep.Posted));
 
-        setFreeCaseStudiesStep1(filterByStep(freeCases, CaseStep.WaitingPreApproval));
-        setFreeCaseStudiesStep2(filterByStep(freeCases, CaseStep.WaitingComity));
-        setFreeCaseStudiesStep3(filterByStep(freeCases, CaseStep.WaitingCatalogue));
-        setFreeCaseStudiesStep4(filterByStep(freeCases, CaseStep.Posted));
-      });
+          setFreeCaseStudiesStep1(filterByStep(freeCases, CaseStep.WaitingPreApproval));
+          setFreeCaseStudiesStep2(filterByStep(freeCases, CaseStep.WaitingComity));
+          setFreeCaseStudiesStep3(filterByStep(freeCases, CaseStep.WaitingCatalogue));
+          setFreeCaseStudiesStep4(filterByStep(freeCases, CaseStep.Posted));
+        }
+      }).catch((err) => {
+        console.log(err);
+      })
   };
 
   React.useEffect(() => {

--- a/client/src/components/roles/ForbiddenPage.tsx
+++ b/client/src/components/roles/ForbiddenPage.tsx
@@ -1,0 +1,10 @@
+import { Typography } from "@mui/material";
+import React from "react";
+
+const ForbiddenPage = () => {
+  return <div>
+    <Typography>Accès interdit</Typography>
+    </div>
+};
+
+export default ForbiddenPage;

--- a/client/src/components/roles/approval/Approval.tsx
+++ b/client/src/components/roles/approval/Approval.tsx
@@ -32,39 +32,43 @@ export default function Approval() {
     axios
       .get(`${process.env.REACT_APP_BASE_API_URL}/api/casestudies/`, {withCredentials: true})
       .then((res) => {
-        const paidCases: Case[] = [];
-        const freeCases: Case[] = [];
-        for (const caseStudy of res.data) {
-          const newData = createCaseFromData(
-            caseStudy._id,
-            caseStudy.title,
-            caseStudy.desc,
-            caseStudy.authors,
-            caseStudy.submitter,
-            caseStudy.date,
-            caseStudy.page,
-            caseStudy.status,
-            caseStudy.isPaidCase,
-            caseStudy.isRejected,
-            caseStudy.classId,
-            caseStudy.discipline,
-            caseStudy.subjects,
-            caseStudy.files,
-            caseStudy.ratings,
-            caseStudy.votes
-          );
-          caseStudy.isPaidCase ? paidCases.push(newData) : freeCases.push(newData);
+        if(res.status === 200) {
+          const paidCases: Case[] = [];
+          const freeCases: Case[] = [];
+          for (const caseStudy of res.data) {
+            const newData = createCaseFromData(
+              caseStudy._id,
+              caseStudy.title,
+              caseStudy.desc,
+              caseStudy.authors,
+              caseStudy.submitter,
+              caseStudy.date,
+              caseStudy.page,
+              caseStudy.status,
+              caseStudy.isPaidCase,
+              caseStudy.isRejected,
+              caseStudy.classId,
+              caseStudy.discipline,
+              caseStudy.subjects,
+              caseStudy.files,
+              caseStudy.ratings,
+              caseStudy.votes
+            );
+            caseStudy.isPaidCase ? paidCases.push(newData) : freeCases.push(newData);
+          }
+  
+          setPaidCaseStudies(paidCases);
+          setPaidCaseStudiesStep1(filterByStep(paidCases, CaseStep.WaitingPreApproval));
+          setPaidCaseStudiesStep2(filterByStep(paidCases, CaseStep.WaitingComity));
+          setPaidCaseStudiesStep3(filterByStep(paidCases, CaseStep.WaitingCatalogue));
+  
+          setFreeCaseStudies(freeCases);
+          setFreeCaseStudiesStep1(filterByStep(freeCases, CaseStep.WaitingPreApproval));
+          setFreeCaseStudiesStep2(filterByStep(freeCases, CaseStep.WaitingComity));
+          setFreeCaseStudiesStep3(filterByStep(freeCases, CaseStep.WaitingCatalogue));
         }
-
-        setPaidCaseStudies(paidCases);
-        setPaidCaseStudiesStep1(filterByStep(paidCases, CaseStep.WaitingPreApproval));
-        setPaidCaseStudiesStep2(filterByStep(paidCases, CaseStep.WaitingComity));
-        setPaidCaseStudiesStep3(filterByStep(paidCases, CaseStep.WaitingCatalogue));
-
-        setFreeCaseStudies(freeCases);
-        setFreeCaseStudiesStep1(filterByStep(freeCases, CaseStep.WaitingPreApproval));
-        setFreeCaseStudiesStep2(filterByStep(freeCases, CaseStep.WaitingComity));
-        setFreeCaseStudiesStep3(filterByStep(freeCases, CaseStep.WaitingCatalogue));
+      }).catch((err) => {
+        console.log(err);
       });
   };
 

--- a/client/src/components/roles/edit/teacher/PendingCaseEdit/PendingCaseEdit.tsx
+++ b/client/src/components/roles/edit/teacher/PendingCaseEdit/PendingCaseEdit.tsx
@@ -21,7 +21,6 @@ import FileUploadIcon from "@mui/icons-material/FileUpload";
 import SaveIcon from "@mui/icons-material/Save";
 import { Document } from "../../../../../model/Document";
 import { createCaseFromData } from "../../../../../utils/ConvertUtils";
-import { ConfirmationDialog } from "../../../../common/ConfirmationDialog";
 
 function PendingCaseEdit() {
   const navigate = useNavigate();

--- a/server/app/constant/constant.ts
+++ b/server/app/constant/constant.ts
@@ -5,7 +5,7 @@ dotenv.config();
 // JWT
 export const PRIVATE_KEY = process.env.ACCESS_TOKEN_PRIVATE_KEY as string;
 export const PUBLIC_KEY = process.env.ACCESS_TOKEN_PUBLIC_KEY as string;
-export const ACCESS_TOKEN_EXPIRES_IN = "15m";
+export const ACCESS_TOKEN_EXPIRES_IN = "60m";
 
 // Email
 export const EMAIL_USERNAME = process.env.EMAIL_USERNAME as string;

--- a/server/app/controllers/caseStudy.controller.ts
+++ b/server/app/controllers/caseStudy.controller.ts
@@ -79,6 +79,16 @@ export class CaseStudyController {
         this.router.get('/:id', async (req: Request, res: Response) => {
             try {
                 const caseStudy = await this.caseStudyService.findCaseStudyById(req.params.id);
+
+                if (!caseStudy) {
+                    res.status(404).json('L\'étude de cas n\'a pas été trouvé');
+                    return;
+                }
+                if(res.locals.user.email !== caseStudy.submitter) {
+                    res.status(403).json('Il est interdit de consulter une étude de cas en cours d\'évaluation déposée par un autre utilisateur');
+                    return;
+                }
+
                 res.json(caseStudy);
             } catch (err: any) {
                 console.log(err);

--- a/server/app/controllers/caseStudy.controller.ts
+++ b/server/app/controllers/caseStudy.controller.ts
@@ -23,7 +23,7 @@ export class CaseStudyController {
         this.router.use(this.middlewareDeserializeUser.bind(this));
 
 
-        this.router.get('/', this.middlewareRestrictTo(Role.Admin, Role.Deputy), async (req: Request, res: Response) => {
+        this.router.get('/', this.middlewareRestrictTo(Role.Admin, Role.Deputy, Role.Comity, Role.PolyPress), async (req: Request, res: Response) => {
             try {
                 const caseStudies = await this.caseStudyService.findAllCaseStudys();
 
@@ -45,7 +45,7 @@ export class CaseStudyController {
 
         });
 
-        this.router.get('/paid', this.middlewareRestrictTo(Role.Admin, Role.Deputy), async (req: Request, res: Response, next: NextFunction) => {
+        this.router.get('/paid', this.middlewareRestrictTo(Role.Admin, Role.Deputy, Role.Comity, Role.PolyPress), async (req: Request, res: Response, next: NextFunction) => {
             try {
                 const caseStudies = await this.caseStudyService.getAllPaidCaseStudies();
 
@@ -84,7 +84,10 @@ export class CaseStudyController {
                     res.status(404).json('L\'étude de cas n\'a pas été trouvé');
                     return;
                 }
-                if(res.locals.user.email !== caseStudy.submitter) {
+                
+                const role = res.locals.user.role;
+                const isNotPrivileged = role === Role.Professor || role === Role.ProfessorNotApproved || role === Role.Student;
+                if(isNotPrivileged && caseStudy.status != CaseStep.Posted && res.locals.user.email !== caseStudy.submitter) {
                     res.status(403).json('Il est interdit de consulter une étude de cas en cours d\'évaluation déposée par un autre utilisateur');
                     return;
                 }

--- a/server/app/controllers/caseStudy.controller.ts
+++ b/server/app/controllers/caseStudy.controller.ts
@@ -81,7 +81,7 @@ export class CaseStudyController {
                 const caseStudy = await this.caseStudyService.findCaseStudyById(req.params.id);
 
                 if (!caseStudy) {
-                    res.status(404).json('L\'étude de cas n\'a pas été trouvé');
+                    res.status(404).json('L\'étude de cas n\'a pas été trouvée');
                     return;
                 }
                 


### PR DESCRIPTION
- Prompt user to login when token expires
- Changed lifetime from 15m to 60m
- Refactored LoginPopup so every component uses the same one
- Made NavBar visible from all pages
- Added logic to manage 403 responses
- Added fail-safes to some get 
requests
- Corrected access to approval page for comity and press
- Corrected 403 condition for get case study by id